### PR TITLE
Remove template provider and replace with calls to templatefile()

### DIFF
--- a/deploy.tf
+++ b/deploy.tf
@@ -61,10 +61,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 3.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.1.2"
-    }
   }
 }
 


### PR DESCRIPTION
This PR replaces the use of the deprecated template provider with a call to the `templatefile()` function.

This also addresses the lack of template provider builds for the M1s.